### PR TITLE
Support firmware 5.x.x in install script

### DIFF
--- a/on_boot.d/install.sh
+++ b/on_boot.d/install.sh
@@ -11,7 +11,7 @@ case "$(ubnt-device-info firmware || true)" in
     DATA_DIR="/mnt/data"
     INSTALL_TYPE=1
     ;;
-2*|3*|4*)
+2*|3*|4*|5*)
     DATA_DIR="/data"
     INSTALL_TYPE=2
     ;;
@@ -46,7 +46,7 @@ elif [ $INSTALL_TYPE -eq 2 ]; then
     #
     echo "#######################################################"
     echo "# Installing ${GH_REPO}"
-    echo "# for firmware v2.x.x, v3.x.x, v4.x.x"
+    echo "# for firmware v2.x.x, v3.x.x, v4.x.x, v5.x.x"
     echo "#######################################################"
     # Install fancontrol if its not already done
     apt list fancontrol 2> /dev/null | grep "installed" && echo "fancontrol already installed" || (echo "Installing fancontrol" && apt install fancontrol -y)


### PR DESCRIPTION
Resolves #18

Only changes the install.sh script to accept 5.x.x version numbers. There seem to be no changes to the fan setup compared to 4.x.x, so no other changes are needed.